### PR TITLE
fix(css): log in buttons centering and text

### DIFF
--- a/fiesta/apps/accounts/templates/account/login.html
+++ b/fiesta/apps/accounts/templates/account/login.html
@@ -43,7 +43,7 @@
       <a href="{% url 'account_reset_password' %}"
          class="link link-neutral link-hover">Lost Password?</a>
     </div>
-    <button type="submit" class="btn btn-primary btn-block">Login to your account</button>
+    <button type="submit" class="btn btn-primary btn-block">Log in to your account</button>
     {# social accounts logins do have their own forms, so it cannot be nested #}
   </form>
   {% include "account/parts/social_login_buttons.html" with process="Log in" %}

--- a/fiesta/apps/accounts/templates/account/parts/social_login_buttons.html
+++ b/fiesta/apps/accounts/templates/account/parts/social_login_buttons.html
@@ -3,7 +3,7 @@
 <div class="flex flex-col space-y-2">
   <a type="button"
      href="{% provider_login_url "esnaccounts" %}"
-     class="text-black bg-white hover:bg-gray-50 border border-2 focus:ring-4 focus:ring-rose-400 inline-block font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center">
+     class="text-black bg-white hover:bg-gray-50 border border-2 focus:ring-4 focus:ring-rose-400 inline-block font-medium rounded-lg text-sm px-5 py-2.5 inline-flex justify-center">
     <svg class="w-6 h-6 mr-2 -ml-1" viewBox="0 0 40 40">
       <use href="{% static "esn-star-color.svg" %}#esn-star-color"></use>
     </svg>


### PR DESCRIPTION
ESN Accounts log in button was centered and the word "login" from the "LOGIN TO YOUR ACCOUNT" button was split into "log in"

Resolves #192 