### PR TITLE
#197 fixed instagram username regex

### DIFF
--- a/fiesta/apps/accounts/models/profile.py
+++ b/fiesta/apps/accounts/models/profile.py
@@ -138,7 +138,7 @@ class UserProfile(LifecycleModelMixin, BaseTimestampedModel):
     )
     instagram = models.CharField(
         verbose_name=_("instagram username"),
-        validators=[RegexValidator(r"^[\w_-.]+$")],
+        validators=[RegexValidator(r"^[\w_.]+$")],
         blank=True,
     )
     telegram = models.CharField(


### PR DESCRIPTION
In instagram user name only underscores and punctuations is allowed, removed minus sign from the regex and tested in onlineregex editor 